### PR TITLE
`got` in dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "array-shuffle": "^1.0.0",
     "each-series": "^1.0.0",
+    "got": "^6.1.1",
     "imgcat": "^0.1.1",
     "tempfile": "^1.1.1"
   }


### PR DESCRIPTION
I saw you using `got`, but it wasn't in dependency list. So I fixed it.

I wish I wasn't a windows user though, is there any cross-platform alternative to `imgcat`?
