### PR TITLE
Gif process inherits stdio

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -73,11 +73,8 @@ function showImage (url, done) {
 
 	image.on('finish', function () {
 		gif = spawn(imgcat, [path], {
-			cwd: process.cwd()
-		});
-
-		gif.stdout.on('data', function (data) {
-			process.stdout.write(data);
+			cwd: process.cwd(),
+			stdio: 'inherit'
 		});
 
 		done();


### PR DESCRIPTION
Just a small patch to avoid listening on gif process `stdout` manually. It just uses the host process `stdout` directly.
