### PR TITLE
chore: use giphy `fixed_height.url` for gifs

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -88,7 +88,7 @@ function showImage (url, done) {
 
 function displayImages (res) {
 	let images = res.body.data.map(function (image) {
-		return image.images.original.url;
+		return image.images.fixed_height.url;
 	});
 
 	each(shuffle(images), function (url, i, done) {


### PR DESCRIPTION
All gifs have the same height(200px) now.
- Improves download/display speed

**GiphyAPI**
https://github.com/Giphy/GiphyAPI#sample-response-search
