### PR TITLE
giffy-break as a non-iTerm fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "array-shuffle": "^1.0.0",
     "cross-spawn-async": "^2.1.9",
     "each-series": "^1.0.0",
+    "giffy-break": "^0.3.0",
     "got": "^5.5.0",
     "imgcat": "^0.1.1",
     "is-iterm": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "array-shuffle": "^1.0.0",
     "cross-spawn-async": "^2.1.9",
     "each-series": "^1.0.0",
-    "giffy-break": "^0.3.0",
+    "giffy-break": "^0.4.1",
     "got": "^5.5.0",
     "imgcat": "^0.1.1",
     "is-iterm": "^1.0.0",


### PR DESCRIPTION
I've got inspired by this module (and by Windows not being able to run it), so I created [`giffy-break`](https://github.com/dsblv/giffy-break) — a reusable module that locally serves a page with random gifs as long as supplied `promise` is beign resolved.

I think it'd be nicer alternative to just opening gifs repeatedly in a viewer. It also a bit faster by using `mp4`-encoded gifs!

---

upd: here's what it looks like

![](https://raw.githubusercontent.com/dsblv/giffy-break/master/media/demo.gif)
