### PR TITLE
Show errors from npm install

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -48,7 +48,7 @@ function isInstall (args) {
 function npm (args) {
 	return spawn('npm', args, {
 		cwd: process.cwd(),
-		stdio: isInstall(args) ? 'ignore' : 'inherit'
+		stdio: isInstall(args) ? ['ignore', 'ignore', process.stderr] : 'inherit'
 	});
 }
 


### PR DESCRIPTION
Fix to show any errors from npm install (example: incorrect package name)
