### PR TITLE
Rollback to got@5 for node 0.12 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "array-shuffle": "^1.0.0",
     "cross-spawn-async": "^2.1.9",
     "each-series": "^1.0.0",
-    "got": "^6.1.1",
+    "got": "^5.5.0",
     "imgcat": "^0.1.1",
     "is-iterm": "^1.0.0",
     "opn": "^4.0.0",


### PR DESCRIPTION
As `got`'s readme [suggests](https://github.com/sindresorhus/got#install), we shouldn't use its latest major if we want our stuff to work in older node versions.

Other than this, everything seems to be working fine in `0.12`.
